### PR TITLE
Recaptcha.net support

### DIFF
--- a/src/Recaptcha.example.js
+++ b/src/Recaptcha.example.js
@@ -38,6 +38,22 @@ storiesOf('Recaptcha', module)
     )),
   )
   .add(
+    'With recaptcha.net',
+    withInfo({
+      text: `I18n https://developers.google.com/recaptcha/docs/language`,
+      inline: true,
+      propTables: [Recaptcha],
+    })(() => (
+      <Recaptcha
+        sitekey={SITE_KEY_LOCALHOST}
+        callback={action('callback')}
+        expiredCallback={action('expiredCallback')}
+        locale="zh-TW"
+        useRecaptchaDotNet={true}
+      />
+    )),
+  )
+  .add(
     'With otherProps',
     withInfo({
       text: `Theme https://developers.google.com/recaptcha/docs/display`,

--- a/src/Recaptcha.example.js
+++ b/src/Recaptcha.example.js
@@ -49,7 +49,7 @@ storiesOf('Recaptcha', module)
         callback={action('callback')}
         expiredCallback={action('expiredCallback')}
         locale="zh-TW"
-        useRecaptchaDotNet={true}
+        useRecaptchaDotNet={Boolean(true)}
       />
     )),
   )

--- a/src/Recaptcha.js
+++ b/src/Recaptcha.js
@@ -70,7 +70,12 @@ class Recaptcha extends React.Component {
   render() {
     const { className, sitekey, invisible, ...otherProps } = this.props;
     const props = {
-      ...omit(otherProps, ['callback', 'expiredCallback', 'locale']),
+      ...omit(otherProps, [
+        'callback',
+        'expiredCallback',
+        'locale',
+        'useRecaptchaDotNet',
+      ]),
       className: c('g-recaptcha', className),
       'data-sitekey': sitekey,
       'data-callback': CALLBACK_NAME,

--- a/src/Recaptcha.js
+++ b/src/Recaptcha.js
@@ -23,22 +23,33 @@ class Recaptcha extends React.Component {
     className: PropTypes.string,
     invisible: PropTypes.bool,
     locale: PropTypes.string,
+    useRecaptchaDotNet: PropTypes.bool,
   };
 
   static defaultProps = {
     locale: 'en',
     className: undefined,
     invisible: false,
+    useRecaptchaDotNet: false,
   };
 
   componentDidMount() {
-    const { locale, callback, expiredCallback } = this.props;
+    const {
+      locale,
+      callback,
+      expiredCallback,
+      useRecaptchaDotNet,
+    } = this.props;
+    let apiHost = 'google.com';
+    if (useRecaptchaDotNet) {
+      apiHost = 'recaptcha.net';
+    }
 
     // 1. Async lazy load
     const head = document.head || document.getElementsByTagName('head')[0];
     const script = document.createElement('script');
     script.id = ID;
-    script.src = `https://www.google.com/recaptcha/api.js?hl=${locale}`;
+    script.src = `https://www.${apiHost}/recaptcha/api.js?hl=${locale}`;
     script.type = 'text/javascript';
     script.async = true;
     script.defer = true;

--- a/src/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/src/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -7,6 +7,7 @@ exports[`Storyshots Recaptcha Invisible reCAPTCHA 1`] = `
   invisible={true}
   locale="zh-TW"
   sitekey="6LdCeh0UAAAAAK8d4SISsIi7KcykpnP7x9D2vlha"
+  useRecaptchaDotNet={false}
 >
   <div
     className="g-recaptcha"
@@ -25,6 +26,7 @@ exports[`Storyshots Recaptcha With locale 1`] = `
   invisible={false}
   locale="zh-TW"
   sitekey="6LehviATAAAAACZ5hcTODQmVldaS5fVHAOKbw3MP"
+  useRecaptchaDotNet={false}
 >
   <div
     className="g-recaptcha"
@@ -43,6 +45,7 @@ exports[`Storyshots Recaptcha With otherProps 1`] = `
   invisible={false}
   locale="en"
   sitekey="6LehviATAAAAACZ5hcTODQmVldaS5fVHAOKbw3MP"
+  useRecaptchaDotNet={false}
 >
   <div
     className="g-recaptcha"
@@ -54,6 +57,24 @@ exports[`Storyshots Recaptcha With otherProps 1`] = `
 </Recaptcha>
 `;
 
+exports[`Storyshots Recaptcha With recaptcha.net 1`] = `
+<Recaptcha
+  callback={[Function]}
+  expiredCallback={[Function]}
+  invisible={false}
+  locale="zh-TW"
+  sitekey="6LehviATAAAAACZ5hcTODQmVldaS5fVHAOKbw3MP"
+  useRecaptchaDotNet={true}
+>
+  <div
+    className="g-recaptcha"
+    data-callback="_grecaptcha.data-callback"
+    data-expired-callback="_grecaptcha.data-expired-callback"
+    data-sitekey="6LehviATAAAAACZ5hcTODQmVldaS5fVHAOKbw3MP"
+  />
+</Recaptcha>
+`;
+
 exports[`Storyshots Recaptcha reCAPTCHA v2 1`] = `
 <Recaptcha
   callback={[Function]}
@@ -61,6 +82,7 @@ exports[`Storyshots Recaptcha reCAPTCHA v2 1`] = `
   invisible={false}
   locale="en"
   sitekey="6LehviATAAAAACZ5hcTODQmVldaS5fVHAOKbw3MP"
+  useRecaptchaDotNet={false}
 >
   <div
     className="g-recaptcha"


### PR DESCRIPTION
Adds a new optional boolean property, `useRecaptchaDotNet`, which, when true, changes the API host to `recaptcha.net`.